### PR TITLE
Remove IO stream redirection to logging facility

### DIFF
--- a/rvic/core/log.py
+++ b/rvic/core/log.py
@@ -12,31 +12,6 @@ LOG_NAME = "rvic"
 FORMATTER = logging.Formatter("%(levelname)s:%(funcName)s>> %(message)s")
 # -------------------------------------------------------------------- #
 
-
-# -------------------------------------------------------------------- #
-# Fake stream file to handle stdin/stdout
-class StreamToFile(object):
-    """
-    Fake file-like stream object that redirects writes to a logger instance.
-    http://www.electricmonk.nl/log/2011/08/14/redirect-stdout-and-stderr-to-a-logger-in-python/
-    """
-
-    def __init__(self, logger_name=LOG_NAME, log_level=logging.INFO):
-        self.logger = logging.getLogger(logger_name)
-        self.log_level = log_level
-        self.linebuf = ""
-
-    def write(self, buf):
-        for line in buf.rstrip().splitlines():
-            self.logger.log(self.log_level, line.rstrip())
-
-    def flush(self):
-        pass
-
-
-# -------------------------------------------------------------------- #
-
-
 def init_logger(log_dir="./", log_level="DEBUG", verbose=False):
     """ Setup the logger """
 
@@ -69,12 +44,6 @@ def init_logger(log_dir="./", log_level="DEBUG", verbose=False):
         logger.addHandler(ch)
     # ---------------------------------------------------------------- #
 
-    # ---------------------------------------------------------------- #
-    # Redirect stdout and stderr to logger
-    sys.stdout = StreamToFile()
-    sys.stderr = StreamToFile(log_level=logging.ERROR)
-    # ---------------------------------------------------------------- #
-
     logger.info("-------------------- INITIALIZED RVIC LOG ------------------")
     logger.info("LOG LEVEL: %s", log_level)
     logger.info("Logging To Console: %s", verbose)
@@ -85,7 +54,6 @@ def init_logger(log_dir="./", log_level="DEBUG", verbose=False):
 
 
 # -------------------------------------------------------------------- #
-
 
 def close_logger():
     """Close the handlers of the logger"""

--- a/tests/unit/test_log.py
+++ b/tests/unit/test_log.py
@@ -1,18 +1,13 @@
 import pytest
-from rvic.core.log import StreamToFile
+from rvic.core.log import init_logger, close_logger
+import sys
 
 
-def test_setup_stream():
-    stream = StreamToFile()
-    stream.write("buf")
-    stream.flush()
+def test_logger():
+    logger = init_logger(log_dir="/tmp", log_level="DEBUG", verbose=False)
+    with open(logger.filename, "r") as log_file:
+        assert log_file.readlines()[3].split()[-1] == logger.filename
 
-
-def test_stream_raises_with_bad_log_level():
-    with pytest.raises(TypeError):
-        stream = StreamToFile(log_level="junk")
-        stream.write("buf")
-        stream.flush()
-
-
-# Cannot test logger in interactive session or using pytest
+    close_logger()
+    with open(logger.filename, "r") as log_file:
+        assert log_file.readlines()[-1].split(">>")[0] == "INFO:close_logger"


### PR DESCRIPTION
resolves #10 

The previous logging strategy caused RecursionError due to the following reason:
1. stdout and stderr are redirected to the logging facility
2. logging facility tries to write to IO streams (stdout & stderr)
3. back to 1

The new logging strategy does not involve any IO stream redirection to the logging facility using a fake file-like object. Therefore, stdout and stderr messages (e.g. Traceback) will only be written to the terminal and won't be found in the log file. The change was manually applied in osprey venv for testing, and no RecursionError has occurred. Moreover, the inability to run multiple processes is also resolved.

Edit:
I found a solution to avoid successive process failures in osprey while keeping the fake file-like object:
- Edit the [write](https://github.com/pacificclimate/rvic-daccs/blob/master/rvic/core/log.py#L29) function to the following:
```
    def write(self, buf):
        for line in buf.rstrip().splitlines():
            sys.stdout = sys.__stdout__
            sys.stderr = sys.__stderr__
            sys.stdout = self.__init__()
            sys.stderr = self.__init__(log_level=logging.ERROR)
            self.logger.log(self.log_level, line.rstrip())
```

But the method is not selected since it does not prevent the RecursionError.